### PR TITLE
Updated readme with syntax coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Based on work by [@pcwalton](https://github.com/pcwalton/). Licensed MIT.
 
 ## Example
 
-```
+```rust
 extern crate iui;
 use iui::prelude::*;
 use iui::controls::{Label, Button, VerticalBox, Group};


### PR DESCRIPTION
The code snippet doesn't have the language specified, which makes it harder to read on github and crates.io. This just specifies the language.