### PR TITLE
Run tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ before_install:
 script:
     - cd ui-sys
     - cargo build --verbose --tests --examples
+    - xvfb-run cargo test
     - cd ../iui
     - cargo build --verbose --tests --examples
+    - xvfb-run cargo test
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/README.md
+++ b/README.md
@@ -88,8 +88,3 @@ fn main() {
     ui.main();
 }
 ```
-
-## Testing Note
-Travis does not connect video devices to their testing environments, so the tests cannot be run. Therefore, the "tests" only check compilation.
-
-[libui]: https://github.com/andlabs/libui


### PR DESCRIPTION
Using [`xvfb`](https://www.x.org/releases/X11R7.7/doc/man/man1/Xvfb.1.xhtml) we can emulate a display in Travis, then run our tests against it.

Thanks for pickup up `libui-rs` and continuing to develop on it! :100: :tada: