### PR TITLE
Fix building against MSVC for new projects

### DIFF
--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -26,23 +26,25 @@ fn main() {
         }
     }
 
+    // Deterimine if we're building for MSVC
+    let target = env::var("TARGET").unwrap();
+    let msvc = target.contains("msvc");
     // Build libui if needed. Otherwise, assume it's in lib/
     let mut dst;
     if cfg!(feature = "build") {
         dst = Config::new("libui").build_target("").profile("release").build();
 
-        let postfix = Path::new("build").join("out");
+        let mut postfix = Path::new("build").join("out");
+        if msvc {
+            postfix = postfix.join("Release");
+        }
         dst = dst.join(&postfix);
     } else {
         dst = env::current_dir()
             .expect("Unable to retrieve current directory location.");
         dst.push("lib");
     }
-    println!("cargo:rustc-link-search=native={}", dst.display());
-
-    // Deterimine if we're building for MSVC
-    let target = env::var("TARGET").unwrap();
-    let msvc = target.contains("msvc");
+    
     
     let libname;
      if msvc {
@@ -50,5 +52,7 @@ fn main() {
     } else {
         libname = "ui";
     }
+
+    println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib={}", libname);
 }

--- a/ui-sys/src/ffi.rs
+++ b/ui-sys/src/ffi.rs
@@ -211,7 +211,7 @@ extern {
 
 pub enum uiEditableCombobox {}
 
-#[link(name = "ui")]
+// #[link(name = "ui")]
 extern {
     pub fn uiNewEditableCombobox() -> *mut uiEditableCombobox;
     pub fn uiEditableComboboxAppend(c: *mut uiEditableCombobox, text: *const c_char);

--- a/ui-sys/src/lib.rs
+++ b/ui-sys/src/lib.rs
@@ -220,7 +220,7 @@ extern {
 
 pub enum uiEditableCombobox {}
 
-#[link(name = "ui")]
+// #[link(name = "ui")]
 extern {
     pub fn uiNewEditableCombobox() -> *mut uiEditableCombobox;
     pub fn uiEditableComboboxAppend(c: *mut uiEditableCombobox, text: *const c_char);


### PR DESCRIPTION
Closes LeoTindall/libui-rs#15
Subsequent project trying to link against UI-SYS would fail
because MSVC likes to put artifacts in places.