### PR TITLE
Remove unsoundness from callbacks by adding 'ctx

### DIFF
--- a/iui/src/controls/basic.rs
+++ b/iui/src/controls/basic.rs
@@ -49,7 +49,7 @@ impl Button {
     }
 
     /// Run the given callback when the button is clicked.
-    pub fn on_clicked<F: FnMut(&mut Button)>(&mut self, _ctx: &UI, callback: F) {
+    pub fn on_clicked<'ctx, F: FnMut(&mut Button) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(&mut Button)>> = Box::new(Box::new(callback));
             ui_sys::uiButtonOnClicked(

--- a/iui/src/controls/entry.rs
+++ b/iui/src/controls/entry.rs
@@ -13,13 +13,13 @@ use ui_sys::{
 pub trait NumericEntry {
     fn value(&self, ctx: &UI) -> i32;
     fn set_value(&mut self, ctx: &UI, value: i32);
-    fn on_changed<F: FnMut(i32)>(&mut self, ctx: &UI, callback: F);
+    fn on_changed<'ctx, F: FnMut(i32) + 'ctx>(&mut self, ctx: &'ctx UI, callback: F);
 }
 
 pub trait TextEntry {
     fn value(&self, ctx: &UI) -> String;
     fn set_value(&mut self, ctx: &UI, value: &str);
-    fn on_changed<F: FnMut(String)>(&mut self, ctx: &UI, callback: F);
+    fn on_changed<'ctx, F: FnMut(String) + 'ctx>(&mut self, ctx: &'ctx UI, callback: F);
 }
 
 define_control!{
@@ -62,7 +62,7 @@ impl NumericEntry for Spinbox {
         unsafe { ui_sys::uiSpinboxSetValue(self.uiSpinbox, value) }
     }
 
-    fn on_changed<F: FnMut(i32)>(&mut self, _ctx: &UI, callback: F) {
+    fn on_changed<'ctx, F: FnMut(i32) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(i32)>> = Box::new(Box::new(callback));
             ui_sys::uiSpinboxOnChanged(
@@ -91,7 +91,7 @@ impl NumericEntry for Slider {
         unsafe { ui_sys::uiSliderSetValue(self.uiSlider, value) }
     }
 
-    fn on_changed<F: FnMut(i32)>(&mut self, _ctx: &UI, callback: F) {
+    fn on_changed<'ctx, F: FnMut(i32) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(i32)>> = Box::new(Box::new(callback));
             ui_sys::uiSliderOnChanged(
@@ -148,7 +148,7 @@ impl TextEntry for Entry {
         unsafe { ui_sys::uiEntrySetText(self.uiEntry, cstring.as_ptr()) }
     }
 
-    fn on_changed<F: FnMut(String)>(&mut self, _ctx: &UI, callback: F) {
+    fn on_changed<'ctx, F: FnMut(String) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(String)>> = Box::new(Box::new(callback));
             ui_sys::uiEntryOnChanged(
@@ -184,7 +184,7 @@ impl TextEntry for MultilineEntry {
         unsafe { ui_sys::uiMultilineEntrySetText(self.uiMultilineEntry, cstring.as_ptr()) }
     }
 
-    fn on_changed<F: FnMut(String)>(&mut self, _ctx: &UI, callback: F) {
+    fn on_changed<'ctx, F: FnMut(String) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(String)>> = Box::new(Box::new(callback));
             ui_sys::uiMultilineEntryOnChanged(

--- a/iui/src/controls/window.rs
+++ b/iui/src/controls/window.rs
@@ -87,7 +87,7 @@ impl Window {
     ///
     /// This is often used on the main window of an application to quit
     /// the application when the window is closed.
-    pub fn on_closing<F: FnMut(&mut Window)>(&mut self, _ctx: &UI, mut callback: F) {
+    pub fn on_closing<'ctx, F: FnMut(&mut Window) + 'ctx>(&mut self, _ctx: &'ctx UI, mut callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(&mut Window) -> bool>> = Box::new(Box::new(|window| {
                 callback(window);

--- a/iui/src/menus.rs
+++ b/iui/src/menus.rs
@@ -46,7 +46,7 @@ impl MenuItem {
     }
 
     /// Sets the function to be executed when the item is clicked/selected.
-    pub fn on_clicked<F: FnMut(&MenuItem, &Window)>(&self, _ctx: &UI, callback: F) {
+    pub fn on_clicked<'ctx, F: FnMut(&MenuItem, &Window) + 'ctx>(&self, _ctx: &'ctx UI, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut(&MenuItem, &Window)>> = Box::new(Box::new(callback));
             ui_sys::uiMenuItemOnClicked(

--- a/iui/src/ui.rs
+++ b/iui/src/ui.rs
@@ -133,7 +133,7 @@ impl UI {
     /// ui.queue_main(|| { println!("Runs second") } );
     /// ui.quit();
     /// ```
-    pub fn queue_main<F: FnMut()>(&self, callback: F) {
+    pub fn queue_main<'ctx, F: FnMut() + 'ctx>(&'ctx self, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut()>> = Box::new(Box::new(callback));
             ui_sys::uiQueueMain(
@@ -145,7 +145,7 @@ impl UI {
     }
 
     /// Set a callback to be run when the application quits.
-    pub fn on_should_quit<F: FnMut()>(&self, callback: F) {
+    pub fn on_should_quit<'ctx, F: FnMut() + 'ctx>(&'ctx self, callback: F) {
         unsafe {
             let mut data: Box<Box<FnMut()>> = Box::new(Box::new(callback));
             ui_sys::uiOnShouldQuit(
@@ -163,18 +163,18 @@ impl UI {
 /// the UI, so do _not_ spin off your UI interactions into an alternative thread. You're likely to
 /// have problems on Mac OS.
 
-pub struct EventLoop {
+pub struct EventLoop<'s> {
     // This PhantomData prevents UIToken from being Send and Sync
     _pd: PhantomData<*mut ()>,
     // This callback gets run during "run_delay" loops.
-    callback: Option<Box<FnMut()>>,
+    callback: Option<Box<FnMut() + 's>>,
 }
 
-impl EventLoop {
+impl<'s> EventLoop<'s> {
     /// Set the given callback to run when the event loop is executed.
     /// Note that if integrating other event loops you should consider
     /// the potential benefits and drawbacks of the various run modes.
-    pub fn on_tick<F: FnMut() + 'static>(&mut self, _ctx: &UI, callback: F) {
+    pub fn on_tick<'ctx, F: FnMut() + 's + 'ctx>(&'ctx mut self, _ctx: &'ctx UI, callback: F) {
         self.callback = Some(Box::new(callback));
     }
 


### PR DESCRIPTION
This lifetime bound ensures that, so long as the context is active, the callback must survive. The context remains as long as the application is running GUI code, so this is sound. Resolves #41 