### PR TITLE
fix readme git link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, in your code, all you have to do is:
 Or, you can track the `master` branch, which may be broken and whose API often changes, with:
 
 ```toml
-iui = { git = "https://github.com/leotindall/libui-rs/iui" }
+iui = { git = "https://github.com/LeoTindall/libui-rs.git" }
 ```
 
 We have documentation on [docs.rs](https://docs.rs/iui) for released versions and on [github](https://leotindall.github.io/libui-rs/iui/index.html) for master.


### PR DESCRIPTION
Hey I just started playing with this repo (looks awesome BTW) but got this error because the git repo name is outdated in the readme:

![scrot5](https://user-images.githubusercontent.com/15269507/51074832-d6000b80-1651-11e9-909f-9e7112b54cf9.jpg)
