### PR TITLE
fix build on modern MacOS systems

### DIFF
--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -42,13 +42,20 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings");
 
-    // Deterimine if we're building for MSVC
+    // Deterimine build platform
     let target = env::var("TARGET").unwrap();
     let msvc = target.contains("msvc");
+    let apple = target.contains("apple");
+
     // Build libui if needed. Otherwise, assume it's in lib/
     let mut dst;
     if cfg!(feature = "build") {
-        dst = Config::new("libui").build_target("").profile("release").build();
+        let mut cfg = Config::new("libui");
+        cfg.build_target("").profile("release");
+        if apple {
+            cfg.cxxflag("--stdlib=libc++");
+        }
+        dst = cfg.build();
 
         let mut postfix = Path::new("build").join("out");
         if msvc {
@@ -62,7 +69,7 @@ fn main() {
     }
 
     let libname;
-     if msvc {
+    if msvc {
         libname = "libui";
     } else {
         libname = "ui";


### PR DESCRIPTION
apple switched c++ stdlibs to support c++1z features, and deprecated the old one.
the ways that interacts with cmake are vast and unknowable. apparently they haven't
gotten around to fixing that yet, which affects libui's cmake-based build toolchain.

what this patch does is essentially just force the new stdlib on apple systems.
i don't think this will cause issues with old (ie, pre-Sierra) macos versions, but
perhaps further testing would be helpful.

at any rate, it fixes a problem that was basically blocking anyone on a modern
macos install from using libui-rs, which is nice.

fixes #38 :)