### PR TITLE
Fix newline issues on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - `RadioButtons` control for groups of radio buttons
 - `Combobox::selected()` method to retrieve the currently selected index of the combobox
 - Officially move communications to the Matrix room #rust-native-ui:matrix.nora.codes
+* `str_tools` module provides utilities for converting to and from system `CString` and
+`CStr` values, while enforcing correct newline values (CR vs CRLF).
 
 ### Changed
 
@@ -29,12 +31,15 @@ No deprecations.
 ### Removed
 
 * `Transform` no longer implements `PartialEq` as the existing implementation was broken.
+* `Button` and `Label` no longer implement `text_ref` as we cannot ensure toolkit newline
+compliance.
 
 ### Fixed
 
 * `VerticalBox` and `HorizontalBox` no longer link to the removed `BoxExt` trait.
 * `ui-sys` now builds on modern macOS.
 * `inputs` and `inputs-grid` examples no longer erroneously start at 0 for inputs starting at 1.
+* Text no longer uses incorrect newlines per platform.
 
 ### Security
 

--- a/iui/Cargo.toml
+++ b/iui/Cargo.toml
@@ -42,3 +42,6 @@ bitflags = "1.0"
 libc = "0.2"
 failure = "0.1.1"
 ui-sys = { path = "../ui-sys", version = "0.2.1" }
+regex = "1"
+lazy_static = "1"
+

--- a/iui/src/controls/basic.rs
+++ b/iui/src/controls/basic.rs
@@ -1,9 +1,9 @@
 use super::Control;
 use std::os::raw::c_void;
-use std::ffi::{CStr, CString};
 use std::mem;
 use ui::UI;
 use ui_sys::{self, uiButton, uiControl, uiLabel};
+use str_tools::{from_toolkit_string, to_toolkit_string};
 
 define_control!{
     /// A non-interactable piece of text.
@@ -20,8 +20,8 @@ define_control!{
 impl Button {
     /// Create a new button with the given text as its label.
     pub fn new(_ctx: &UI, text: &str) -> Button {
+        let c_string = to_toolkit_string(text);
         unsafe {
-            let c_string = CString::new(text.as_bytes().to_vec()).unwrap();
             Button::from_raw(ui_sys::uiNewButton(c_string.as_ptr()))
         }
     }
@@ -29,21 +29,14 @@ impl Button {
     /// Get a copy of the existing text on the button.
     pub fn text(&self, _ctx: &UI) -> String {
         unsafe {
-            CStr::from_ptr(ui_sys::uiButtonText(self.uiButton))
-                .to_string_lossy()
-                .into_owned()
+            from_toolkit_string(ui_sys::uiButtonText(self.uiButton))
         }
-    }
-
-    /// Get a reference to the existing text on the button.
-    pub fn text_ref(&self, _ctx: &UI) -> &CStr {
-        unsafe { CStr::from_ptr(ui_sys::uiButtonText(self.uiButton)) }
     }
 
     /// Set the text on the button.
     pub fn set_text(&mut self, _ctx: &UI, text: &str) {
+        let c_string = to_toolkit_string(text);
         unsafe {
-            let c_string = CString::new(text.as_bytes().to_vec()).unwrap();
             ui_sys::uiButtonSetText(self.uiButton, c_string.as_ptr())
         }
     }
@@ -74,8 +67,8 @@ impl Label {
     /// Note that labels do not auto-wrap their text; they will expand as far as needed
     /// to fit.
     pub fn new(_ctx: &UI, text: &str) -> Label {
+        let c_string = to_toolkit_string(text);
         unsafe {
-            let c_string = CString::new(text.as_bytes().to_vec()).unwrap();
             Label::from_raw(ui_sys::uiNewLabel(c_string.as_ptr()))
         }
     }
@@ -83,21 +76,14 @@ impl Label {
     /// Get a copy of the existing text on the label.
     pub fn text(&self, _ctx: &UI) -> String {
         unsafe {
-            CStr::from_ptr(ui_sys::uiLabelText(self.uiLabel))
-                .to_string_lossy()
-                .into_owned()
+            from_toolkit_string(ui_sys::uiLabelText(self.uiLabel))
         }
-    }
-
-    /// Get a reference to the existing text on the label.
-    pub fn text_ref(&self, _ctx: &UI) -> &CStr {
-        unsafe { CStr::from_ptr(ui_sys::uiLabelText(self.uiLabel)) }
     }
 
     /// Set the text on the label.
     pub fn set_text(&mut self, _ctx: &UI, text: &str) {
+        let c_string = to_toolkit_string(text);
         unsafe {
-            let c_string = CString::new(text.as_bytes().to_vec()).unwrap();
             ui_sys::uiLabelSetText(self.uiLabel, c_string.as_ptr())
         }
     }

--- a/iui/src/controls/entry.rs
+++ b/iui/src/controls/entry.rs
@@ -1,15 +1,19 @@
 //! User input mechanisms: numbers, colors, and text in various forms.
+//!
+//! All text buffers accept and return `\n` line endings; if on Windows, the appropriate
+//! `\r\n` for display are added and removed by the controls.
 
 use super::Control;
 use std::ffi::{CStr, CString};
 use std::i32;
 use std::mem;
 use std::os::raw::c_void;
-use ui::UI;
 use ui_sys::{
     self, uiCheckbox, uiCombobox, uiControl, uiEntry, uiMultilineEntry, uiRadioButtons, uiSlider,
     uiSpinbox,
 };
+use ui::UI;
+use str_tools::{from_toolkit_string, to_toolkit_string};
 
 pub trait NumericEntry {
     fn value(&self, ctx: &UI) -> i32;
@@ -150,14 +154,11 @@ impl MultilineEntry {
 
 impl TextEntry for Entry {
     fn value(&self, _ctx: &UI) -> String {
-        unsafe {
-            CStr::from_ptr(ui_sys::uiEntryText(self.uiEntry))
-                .to_string_lossy()
-                .into_owned()
-        }
+        unsafe { from_toolkit_string(ui_sys::uiEntryText(self.uiEntry)) }
     }
+
     fn set_value(&mut self, _ctx: &UI, value: &str) {
-        let cstring = CString::new(value.as_bytes().to_vec()).unwrap();
+        let cstring = to_toolkit_string(value);
         unsafe { ui_sys::uiEntrySetText(self.uiEntry, cstring.as_ptr()) }
     }
 
@@ -210,9 +211,7 @@ impl TextEntry for PasswordEntry {
 
         extern "C" fn c_callback(entry: *mut uiEntry, data: *mut c_void) {
             unsafe {
-                let string = CStr::from_ptr(ui_sys::uiEntryText(entry))
-                    .to_string_lossy()
-                    .into_owned();
+                let string = from_toolkit_string(ui_sys::uiEntryText(entry));
                 mem::transmute::<*mut c_void, &mut Box<dyn FnMut(String)>>(data)(string);
                 mem::forget(entry);
             }
@@ -223,13 +222,12 @@ impl TextEntry for PasswordEntry {
 impl TextEntry for MultilineEntry {
     fn value(&self, _ctx: &UI) -> String {
         unsafe {
-            CStr::from_ptr(ui_sys::uiMultilineEntryText(self.uiMultilineEntry))
-                .to_string_lossy()
-                .into_owned()
+            from_toolkit_string(ui_sys::uiMultilineEntryText(self.uiMultilineEntry))
         }
     }
+
     fn set_value(&mut self, _ctx: &UI, value: &str) {
-        let cstring = CString::new(value.as_bytes().to_vec()).unwrap();
+        let cstring = to_toolkit_string(value);
         unsafe { ui_sys::uiMultilineEntrySetText(self.uiMultilineEntry, cstring.as_ptr()) }
     }
 
@@ -246,9 +244,7 @@ impl TextEntry for MultilineEntry {
 
         extern "C" fn c_callback(entry: *mut uiMultilineEntry, data: *mut c_void) {
             unsafe {
-                let string = CStr::from_ptr(ui_sys::uiMultilineEntryText(entry))
-                    .to_string_lossy()
-                    .into_owned();
+                let string = from_toolkit_string(ui_sys::uiMultilineEntryText(entry));
                 mem::transmute::<*mut c_void, &mut Box<dyn FnMut(String)>>(data)(string);
                 mem::forget(entry);
             }
@@ -271,7 +267,7 @@ impl Combobox {
     /// Adds a new option to the combination box.
     pub fn append(&self, _ctx: &UI, name: &str) {
         unsafe {
-            let c_string = CString::new(name.as_bytes().to_vec()).unwrap();
+            let c_string = to_toolkit_string(name);
             ui_sys::uiComboboxAppend(self.uiCombobox, c_string.as_ptr())
         }
     }
@@ -314,7 +310,7 @@ define_control! {
 impl Checkbox {
     // Create a new Checkbox which can produce values from `min` to `max`.
     pub fn new(_ctx: &UI, text: &str) -> Self {
-        let c_string = CString::new(text.as_bytes().to_vec()).unwrap();
+        let c_string = to_toolkit_string(text);
         unsafe { Checkbox::from_raw(ui_sys::uiNewCheckbox(c_string.as_ptr())) }
     }
 

--- a/iui/src/lib.rs
+++ b/iui/src/lib.rs
@@ -21,8 +21,11 @@
 extern crate bitflags;
 #[macro_use]
 extern crate failure;
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 extern crate ui_sys;
+extern crate regex;
 
 pub mod controls;
 pub mod draw;
@@ -30,6 +33,7 @@ mod error;
 mod ffi_tools;
 pub mod menus;
 mod ui;
+pub mod str_tools;
 
 pub use error::UIError;
 pub use ui::{EventLoop, UI};

--- a/iui/src/str_tools.rs
+++ b/iui/src/str_tools.rs
@@ -1,0 +1,78 @@
+//! Tools for making platform-independent string handling work properly
+
+use regex::{Regex, RegexBuilder};
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+/// Replaces every occurrance of `"\r\n"` with a single newline `\n`, without collapsing
+/// newlines.
+pub fn strip_dual_endings(s: &str) -> String {
+    s.replace("\r\n", "\n")
+}
+
+/// Replaces every occurrance of `"\n"` not followed by `"\r"` with `"\r\n"`.
+pub fn insert_dual_endings(s: &str) -> String {
+    lazy_static! {
+        //static ref RE: Regex = Regex::new("([^\r])\n").expect("Could not compile regex");
+        static ref RE: Regex = RegexBuilder::new("\r\n|\n")
+                                             .multi_line(true)
+                                             .build()
+                                             .expect("Could not compile regex");
+    }
+    RE.replace_all(s, "\r\n").to_string()
+}
+
+/// Converts a &str to a CString, using either LF or CRLF as appropriate.
+///
+/// # Panics
+/// Panics if it isn't possible to create a CString from the given string.
+pub fn to_toolkit_string(s: &str) -> CString {
+    let data = if cfg!(windows) { 
+        insert_dual_endings(s).as_bytes().to_vec()
+    } else {
+        s.as_bytes().to_vec()
+    };
+    CString::new(data).expect(&format!("Failed to create CString from {}", s))
+}
+
+/// Converts a `*mut c_char` to a String guaranteed to use LF line endings.
+/// 
+/// # Unsafety
+/// Has the same unsafety as [CStr::from_ptr](https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_ptr).
+pub unsafe fn from_toolkit_string(c: *mut c_char) -> String {
+    CStr::from_ptr(c).to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn strip_dual_endings_to_single() {
+        assert_eq!(strip_dual_endings("Line 1\r\nLine 2\r\n"),
+                   "Line 1\nLine 2\n");
+    }
+
+    #[test]
+    fn insert_dual_endings_basic() {
+        assert_eq!(insert_dual_endings("Line 1\nLine 2\n"),
+                   "Line 1\r\nLine 2\r\n");
+    }
+
+    #[test]
+    fn insert_dual_endings_nodupe() {
+        assert_eq!(insert_dual_endings("Line 1\r\nLine 2\r\n"),
+                   "Line 1\r\nLine 2\r\n");
+    }
+    
+    #[test]
+    fn test_toolkit_roundtripping() {
+        let initial_string = "Here is some test data.\n\nMultiline!\n";
+        let toolkit_string = to_toolkit_string(initial_string);
+        let roundtripped_string = unsafe {
+            from_toolkit_string(toolkit_string.into_raw())
+        };
+        assert_eq!(initial_string, &roundtripped_string);
+    }
+}
+


### PR DESCRIPTION
Now all text is checked on input and output for the correct line
endings, normalized to UNIX (CR) line endings. Closes issue
#37 