### PR TITLE
Add uiColorButton

### DIFF
--- a/iui/examples/basic.rs
+++ b/iui/examples/basic.rs
@@ -1,13 +1,13 @@
 extern crate iui;
+use iui::controls::{Button, ColorButton, Group, Label, Rgba, VerticalBox};
 use iui::prelude::*;
-use iui::controls::{Label, Button, VerticalBox, Group};
 
 fn main() {
     // Initialize the UI library
     let ui = UI::init().expect("Couldn't initialize UI library");
     // Create a window into which controls can be placed
     let mut win = Window::new(&ui, "Test App", 200, 200, WindowType::NoMenubar);
-    
+
     // Create a vertical layout to hold the controls
     let mut vbox = VerticalBox::new(&ui);
     vbox.set_padded(&ui, true);
@@ -32,6 +32,23 @@ fn main() {
         }
     });
 
+    let mut color_button = ColorButton::new(&ui);
+    color_button.set_color(
+        &ui,
+        Rgba {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+    );
+    color_button.on_changed(&ui, {
+        let ui = ui.clone();
+        move |btn| {
+            dbg!(btn.color(&ui));
+        }
+    });
+
     // Create a new label. Note that labels don't auto-wrap!
     let mut label_text = String::new();
     label_text.push_str("There is a ton of text in this label.\n");
@@ -42,6 +59,7 @@ fn main() {
     vbox.append(&ui, label, LayoutStrategy::Stretchy);
     group_vbox.append(&ui, button, LayoutStrategy::Compact);
     group_vbox.append(&ui, quit_button, LayoutStrategy::Compact);
+    group_vbox.append(&ui, color_button, LayoutStrategy::Compact);
     group.set_child(&ui, group_vbox);
     vbox.append(&ui, group, LayoutStrategy::Compact);
 

--- a/iui/src/controls/basic.rs
+++ b/iui/src/controls/basic.rs
@@ -5,7 +5,7 @@ use std::mem;
 use ui::UI;
 use ui_sys::{self, uiButton, uiColorButton, uiControl, uiLabel};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Rgba {
     pub r: f64,
     pub g: f64,


### PR DESCRIPTION
This adds support for uiColorButton and also updates an example to use it.

The `Rgba` struct shouldn't be in `controls/basic.rs`, I've tried putting it into `util_types.rs` but couldn't find a way to include/use that (sorry, Rust noob here).