### PR TITLE
Throttle UI::run_delay

### DIFF
--- a/iui/src/ui.rs
+++ b/iui/src/ui.rs
@@ -7,8 +7,8 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem;
 use std::rc::Rc;
-use std::thread::sleep;
-use std::time::Duration;
+use std::thread;
+use std::time::{Duration, SystemTime};
 
 use controls::Window;
 
@@ -218,11 +218,27 @@ impl<'s> EventLoop<'s> {
     /// running the callback given with `on_tick` approximately every
     /// `delay` milliseconds.
     pub fn run_delay(&mut self, ctx: &UI, delay_ms: u32) {
-        loop {
-            if !self.next_tick(ctx) {
-                break;
+        if let Some(ref mut c) = self.callback {
+            let delay_ms = delay_ms as u128;
+            let mut t0 = SystemTime::now();
+            'event_loop: loop {
+                for _ in 0..5 {
+                    if !unsafe { ui_sys::uiMainStep(false as c_int) == 1 } {
+                        break 'event_loop;
+                    }
+                }
+                if let Ok(duration) = t0.elapsed() {
+                    if duration.as_millis() >= delay_ms {
+                        c();
+                        t0 = SystemTime::now();
+                    }
+                } else {
+                    t0 = SystemTime::now();
+                }
+                thread::sleep(Duration::from_millis(5));
             }
+        } else {
+            self.run(ctx)
         }
-        sleep(Duration::new(0, delay_ms * 1000000))
     }
 }


### PR DESCRIPTION
When building an UI for an app the has long-running background processes that need to be monitored I noticed that `run_delay` calls the `on_tick` callback very aggressively. This change would trigger the callback on every `delay_ms` milliseconds (as advertised) without consuming a whole CPU core.