### PR TITLE
Fix build warnings on Rust 1.37+

### DIFF
--- a/iui/src/controls/area.rs
+++ b/iui/src/controls/area.rs
@@ -23,11 +23,11 @@ pub trait AreaHandler {
 #[repr(C)]
 struct RustAreaHandler {
     ui_area_handler: uiAreaHandler,
-    trait_object: Box<AreaHandler>,
+    trait_object: Box<dyn AreaHandler>,
 }
 
 impl RustAreaHandler {
-    fn new(_ctx: &UI, trait_object: Box<AreaHandler>) -> Box<RustAreaHandler> {
+    fn new(_ctx: &UI, trait_object: Box<dyn AreaHandler>) -> Box<RustAreaHandler> {
         return Box::new(RustAreaHandler {
             ui_area_handler: uiAreaHandler {
                 Draw: Some(draw),
@@ -148,7 +148,7 @@ define_control! {
 
 impl Area {
     /// Creates a new non-scrolling area.
-    pub fn new(ctx: &UI, area_handler: Box<AreaHandler>) -> Area {
+    pub fn new(ctx: &UI, area_handler: Box<dyn AreaHandler>) -> Area {
         unsafe {
             let mut rust_area_handler = RustAreaHandler::new(ctx, area_handler);
             let area = Area::from_raw(ui_sys::uiNewArea(
@@ -162,7 +162,7 @@ impl Area {
     /// Creates a new scrolling area.
     pub fn new_scrolling(
         ctx: &UI,
-        area_handler: Box<AreaHandler>,
+        area_handler: Box<dyn AreaHandler>,
         width: i64,
         height: i64,
     ) -> Area {

--- a/iui/src/controls/basic.rs
+++ b/iui/src/controls/basic.rs
@@ -51,11 +51,11 @@ impl Button {
     /// Run the given callback when the button is clicked.
     pub fn on_clicked<'ctx, F: FnMut(&mut Button) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(&mut Button)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(&mut Button)>> = Box::new(Box::new(callback));
             ui_sys::uiButtonOnClicked(
                 self.uiButton,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(&mut Button)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(&mut Button)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -63,7 +63,7 @@ impl Button {
         extern "C" fn c_callback(button: *mut uiButton, data: *mut c_void) {
             unsafe {
                 let mut button = Button { uiButton: button };
-                mem::transmute::<*mut c_void, &mut Box<FnMut(&mut Button)>>(data)(&mut button)
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(&mut Button)>>(data)(&mut button)
             }
         }
     }

--- a/iui/src/controls/entry.rs
+++ b/iui/src/controls/entry.rs
@@ -65,11 +65,11 @@ impl NumericEntry for Spinbox {
 
     fn on_changed<'ctx, F: FnMut(i32) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(i32)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(i32)>> = Box::new(Box::new(callback));
             ui_sys::uiSpinboxOnChanged(
                 self.uiSpinbox,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(i32)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(i32)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -77,7 +77,7 @@ impl NumericEntry for Spinbox {
         extern "C" fn c_callback(spinbox: *mut uiSpinbox, data: *mut c_void) {
             unsafe {
                 let val = ui_sys::uiSpinboxValue(spinbox);
-                mem::transmute::<*mut c_void, &mut Box<FnMut(i32)>>(data)(val);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(i32)>>(data)(val);
             }
         }
     }
@@ -94,11 +94,11 @@ impl NumericEntry for Slider {
 
     fn on_changed<'ctx, F: FnMut(i32) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(i32)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(i32)>> = Box::new(Box::new(callback));
             ui_sys::uiSliderOnChanged(
                 self.uiSlider,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(i32)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(i32)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -106,7 +106,7 @@ impl NumericEntry for Slider {
         extern "C" fn c_callback(slider: *mut uiSlider, data: *mut c_void) {
             unsafe {
                 let val = ui_sys::uiSliderValue(slider);
-                mem::transmute::<*mut c_void, &mut Box<FnMut(i32)>>(data)(val);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(i32)>>(data)(val);
             }
         }
     }
@@ -163,11 +163,11 @@ impl TextEntry for Entry {
 
     fn on_changed<'ctx, F: FnMut(String) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(String)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(String)>> = Box::new(Box::new(callback));
             ui_sys::uiEntryOnChanged(
                 self.uiEntry,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(String)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(String)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -177,7 +177,7 @@ impl TextEntry for Entry {
                 let string = CStr::from_ptr(ui_sys::uiEntryText(entry))
                     .to_string_lossy()
                     .into_owned();
-                mem::transmute::<*mut c_void, &mut Box<FnMut(String)>>(data)(string);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(String)>>(data)(string);
                 mem::forget(entry);
             }
         }
@@ -199,11 +199,11 @@ impl TextEntry for PasswordEntry {
 
     fn on_changed<'ctx, F: FnMut(String) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(String)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(String)>> = Box::new(Box::new(callback));
             ui_sys::uiEntryOnChanged(
                 self.uiEntry,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(String)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(String)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -213,7 +213,7 @@ impl TextEntry for PasswordEntry {
                 let string = CStr::from_ptr(ui_sys::uiEntryText(entry))
                     .to_string_lossy()
                     .into_owned();
-                mem::transmute::<*mut c_void, &mut Box<FnMut(String)>>(data)(string);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(String)>>(data)(string);
                 mem::forget(entry);
             }
         }
@@ -235,11 +235,11 @@ impl TextEntry for MultilineEntry {
 
     fn on_changed<'ctx, F: FnMut(String) + 'ctx>(&mut self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(String)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(String)>> = Box::new(Box::new(callback));
             ui_sys::uiMultilineEntryOnChanged(
                 self.uiMultilineEntry,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(String)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(String)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -249,7 +249,7 @@ impl TextEntry for MultilineEntry {
                 let string = CStr::from_ptr(ui_sys::uiMultilineEntryText(entry))
                     .to_string_lossy()
                     .into_owned();
-                mem::transmute::<*mut c_void, &mut Box<FnMut(String)>>(data)(string);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(String)>>(data)(string);
                 mem::forget(entry);
             }
         }
@@ -287,11 +287,11 @@ impl Combobox {
 
     pub fn on_selected<F: FnMut(i32)>(&mut self, _ctx: &UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(i32)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(i32)>> = Box::new(Box::new(callback));
             ui_sys::uiComboboxOnSelected(
                 self.uiCombobox,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(i32)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(i32)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -299,7 +299,7 @@ impl Combobox {
         extern "C" fn c_callback(combobox: *mut uiCombobox, data: *mut c_void) {
             unsafe {
                 let val = ui_sys::uiComboboxSelected(combobox);
-                mem::transmute::<*mut c_void, &mut Box<FnMut(i32)>>(data)(val);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(i32)>>(data)(val);
             }
         }
     }
@@ -328,11 +328,11 @@ impl Checkbox {
 
     pub fn on_toggled<F: FnMut(bool)>(&mut self, _ctx: &UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(bool)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(bool)>> = Box::new(Box::new(callback));
             ui_sys::uiCheckboxOnToggled(
                 self.uiCheckbox,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(bool)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(bool)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -340,7 +340,7 @@ impl Checkbox {
         extern "C" fn c_callback(checkbox: *mut uiCheckbox, data: *mut c_void) {
             unsafe {
                 let val = ui_sys::uiCheckboxChecked(checkbox) != 0;
-                mem::transmute::<*mut c_void, &mut Box<FnMut(bool)>>(data)(val);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(bool)>>(data)(val);
             }
         }
     }
@@ -372,11 +372,11 @@ impl RadioButtons {
 
     pub fn on_selected<'ctx, F: FnMut(i32) + 'ctx>(&self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(i32)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(i32)>> = Box::new(Box::new(callback));
             ui_sys::uiRadioButtonsOnSelected(
                 self.uiRadioButtons,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(i32)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(i32)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -384,7 +384,7 @@ impl RadioButtons {
         extern "C" fn c_callback(radio_buttons: *mut uiRadioButtons, data: *mut c_void) {
             unsafe {
                 let val = ui_sys::uiRadioButtonsSelected(radio_buttons);
-                mem::transmute::<*mut c_void, &mut Box<FnMut(i32)>>(data)(val);
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(i32)>>(data)(val);
             }
         }
     }

--- a/iui/src/controls/window.rs
+++ b/iui/src/controls/window.rs
@@ -89,14 +89,14 @@ impl Window {
     /// the application when the window is closed.
     pub fn on_closing<'ctx, F: FnMut(&mut Window) + 'ctx>(&mut self, _ctx: &'ctx UI, mut callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(&mut Window) -> bool>> = Box::new(Box::new(|window| {
+            let mut data: Box<Box<dyn FnMut(&mut Window) -> bool>> = Box::new(Box::new(|window| {
                 callback(window);
                 false
             }));
             ui_sys::uiWindowOnClosing(
                 self.uiWindow,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(&mut Window) -> bool> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(&mut Window) -> bool> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -104,7 +104,7 @@ impl Window {
         extern "C" fn c_callback(window: *mut uiWindow, data: *mut c_void) -> i32 {
             unsafe {
                 let mut window = Window { uiWindow: window };
-                mem::transmute::<*mut c_void, Box<Box<FnMut(&mut Window) -> bool>>>(data)(
+                mem::transmute::<*mut c_void, Box<Box<dyn FnMut(&mut Window) -> bool>>>(data)(
                     &mut window,
                 ) as i32
             }

--- a/iui/src/draw/transform.rs
+++ b/iui/src/draw/transform.rs
@@ -19,9 +19,9 @@ impl Transform {
     /// Create a new Transform that does nothing.
     pub fn identity() -> Transform {
         unsafe {
-            let mut matrix = mem::uninitialized();
-            ui_sys::uiDrawMatrixSetIdentity(&mut matrix);
-            Transform::from_ui_matrix(&matrix)
+            let mut matrix = mem::MaybeUninit::uninit();
+            ui_sys::uiDrawMatrixSetIdentity(matrix.as_mut_ptr());
+            Transform::from_ui_matrix(&matrix.assume_init())
         }
     }
 

--- a/iui/src/ffi_tools.rs
+++ b/iui/src/ffi_tools.rs
@@ -1,7 +1,7 @@
 //! Utilities to manage the state of the interface to the libUI bindings.
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-static INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 /// Set the global flag stating that libUI is initialized.
 ///

--- a/iui/src/menus.rs
+++ b/iui/src/menus.rs
@@ -48,11 +48,11 @@ impl MenuItem {
     /// Sets the function to be executed when the item is clicked/selected.
     pub fn on_clicked<'ctx, F: FnMut(&MenuItem, &Window) + 'ctx>(&self, _ctx: &'ctx UI, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut(&MenuItem, &Window)>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut(&MenuItem, &Window)>> = Box::new(Box::new(callback));
             ui_sys::uiMenuItemOnClicked(
                 self.ui_menu_item,
                 Some(c_callback),
-                &mut *data as *mut Box<FnMut(&MenuItem, &Window)> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut(&MenuItem, &Window)> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -67,7 +67,7 @@ impl MenuItem {
                     ui_menu_item: menu_item,
                 };
                 let window = Window::from_raw(window);
-                mem::transmute::<*mut c_void, &mut Box<FnMut(&MenuItem, &Window)>>(data)(
+                mem::transmute::<*mut c_void, &mut Box<dyn FnMut(&MenuItem, &Window)>>(data)(
                     &menu_item, &window,
                 );
                 mem::forget(window);

--- a/iui/src/ui.rs
+++ b/iui/src/ui.rs
@@ -135,10 +135,10 @@ impl UI {
     /// ```
     pub fn queue_main<'ctx, F: FnMut() + 'ctx>(&'ctx self, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut()>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut()>> = Box::new(Box::new(callback));
             ui_sys::uiQueueMain(
                 None,
-                &mut *data as *mut Box<FnMut()> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut()> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -147,10 +147,10 @@ impl UI {
     /// Set a callback to be run when the application quits.
     pub fn on_should_quit<'ctx, F: FnMut() + 'ctx>(&'ctx self, callback: F) {
         unsafe {
-            let mut data: Box<Box<FnMut()>> = Box::new(Box::new(callback));
+            let mut data: Box<Box<dyn FnMut()>> = Box::new(Box::new(callback));
             ui_sys::uiOnShouldQuit(
                 None,
-                &mut *data as *mut Box<FnMut()> as *mut c_void,
+                &mut *data as *mut Box<dyn FnMut()> as *mut c_void,
             );
             mem::forget(data);
         }
@@ -167,7 +167,7 @@ pub struct EventLoop<'s> {
     // This PhantomData prevents UIToken from being Send and Sync
     _pd: PhantomData<*mut ()>,
     // This callback gets run during "run_delay" loops.
-    callback: Option<Box<FnMut() + 's>>,
+    callback: Option<Box<dyn FnMut() + 's>>,
 }
 
 impl<'s> EventLoop<'s> {


### PR DESCRIPTION
This patchset fixes build warnings that were encountered when using Rust 1.42.0.  These most likely exist on any Rust version since 1.37.

Note that this bumps the MSRV up to at least 1.36, since that's when `mem::MaybeUninit` was introduced.