### PR TITLE
fix: prevent menus from being created after windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 * The semi-unstable `iui::draw` subsystem is again exported to downstream consumers of the `iui` crate.
 * `UI::queue_main` and `UI::on_should_quit` now require passed closures to be `'static`, for soundness
 * All callback registration functions require that their callbacks live at least as long as the `UI` token, for soundness
+* `Menu` methods now returns `Option<>` because menus can't always be created or
+modified
 
 ### Deprecated
 
@@ -44,6 +46,7 @@ compliance.
 * Text no longer uses incorrect newlines per platform.
 * `UI::run_delay` no longer spins on the callback, but actually calls it at the
 appropriate interval
+* Menus can no longer be created or modified after windows, as this causes crashes.
 
 ### Security
 

--- a/iui/src/controls/window.rs
+++ b/iui/src/controls/window.rs
@@ -4,10 +4,12 @@ use callback_helpers::{from_void_ptr, to_heap_ptr};
 use controls::Control;
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
+use std::sync::atomic::{Ordering};
 use std::mem;
 use std::os::raw::{c_int, c_void};
 use std::path::PathBuf;
 use ui::UI;
+use menus::{HAS_FINALIZED_MENUS};
 use ui_sys::{self, uiControl, uiWindow};
 
 thread_local! {
@@ -15,6 +17,8 @@ thread_local! {
 }
 
 /// A `Window` can either have a menubar or not; this enum represents that decision.\
+///
+/// Once one window is created, no changes to menus can be made.
 #[derive(Clone, Copy, Debug)]
 pub enum WindowType {
     HasMenubar,
@@ -46,6 +50,7 @@ impl Window {
             ));
 
             WINDOWS.with(|windows| windows.borrow_mut().push(window.clone()));
+            HAS_FINALIZED_MENUS.store(true, Ordering::SeqCst);
 
             window
         };

--- a/iui/src/lib.rs
+++ b/iui/src/lib.rs
@@ -47,3 +47,4 @@ pub mod prelude {
     pub use controls::{Window, WindowType};
     pub use ui::UI;
 }
+


### PR DESCRIPTION
Closes #40 

Ideally we will eventually get a better API for this