### PR TITLE
Whitelist only libui declarations in bindings

### DIFF
--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -40,7 +40,9 @@ fn main() {
     // Generate libui bindings on the fly
     let bindings = BindgenBuilder::default()
         .header("wrapper.h")
-        .opaque_type("max_align_t") // For some reason this ends up too large
+        .whitelist_function("ui[A-Z].+")
+        .whitelist_type("ui[A-Z].+")
+        .whitelist_var("ui[A-Z].+")
         //.rustified_enum(".*")
         .trust_clang_mangling(false) // clang sometimes wants to treat these functions as C++
         .generate()


### PR DESCRIPTION
Cuts down on stuff like this, on every platform:

![image](https://user-images.githubusercontent.com/4723091/91123708-5e2dfb80-e652-11ea-8edb-a5af912dea11.png)

Reduces the size of the generated bindings on my platform from 3476 lines to 2775, while `iui` is still fully functional. Granted, I'm comparing this PR to my own modified version (notice how I have like 5 pull requests open right now?), but that is a huge difference.