### PR TITLE
Queueing async and sync functions on the main thread

### DIFF
--- a/iui/src/async.rs
+++ b/iui/src/async.rs
@@ -1,0 +1,110 @@
+use callback_helpers::{from_void_ptr, to_heap_ptr};
+use std::os::raw::c_void;
+use std::sync::Arc;
+use std::future::Future;
+
+/// Evidence that it's safe to call `ui_sys:uiQueueMain`; ie that `UI:init()`
+/// has been run.
+#[derive(Copy,Clone)]
+pub struct Context {}
+
+impl Context {
+    /// Queues a function to be executed on the GUI thread when next possible. Returns
+    /// immediately, not waiting for the function to be executed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use iui::prelude::*;
+    ///
+    /// let ui = UI::init().unwrap();
+    ///
+    /// ui.queue_main(|| { println!("Runs first") } );
+    /// ui.queue_main(|| { println!("Runs second") } );
+    /// ui.quit();
+    /// ```
+    pub fn queue_main<F: FnMut() + Send + 'static>(self, callback: F) {
+        queue_main_unsafe(callback)
+    }
+
+    /// Spawns a new asynchronous task on the GUI thread when next possible.
+    /// Returns immediately, not waiting for the task to be executed.
+    /// The GUI thread will resume normal operation when the task completes
+    /// or when it is awaiting. This version can be used from any thread.
+    /// The `Send` restriction lets us safely use this function from
+    /// other threads.
+    pub fn spawn<F: Future<Output = ()> + Send + 'static>(self, future: F) {
+        let arc = std::sync::Arc::new(future);
+        unsafe { spawn_unsafe(arc) }
+    }
+}
+
+/// Queues a function to be executed on the GUI thread with no evidence that
+/// it's safe to do so yet.
+pub(crate) fn queue_main_unsafe<F: FnMut() + 'static>(callback: F) {
+    extern "C" fn c_callback<G: FnMut()>(data: *mut c_void) {
+        unsafe {
+            from_void_ptr::<G>(data)();
+        }
+    }
+
+    unsafe {
+        ui_sys::uiQueueMain(Some(c_callback::<F>), to_heap_ptr(callback));
+    }
+}
+
+pub(crate) unsafe fn spawn_unsafe<F: Future<Output = ()> + 'static>(arc: Arc<F>) {
+    queue_main_unsafe(move || {
+        let waker = waker::make_waker(&arc.clone());
+        let mut ctx = std::task::Context::from_waker(&waker);
+        match F::poll(std::pin::Pin::new_unchecked(Arc::get_mut(&mut arc.clone()).unwrap()), &mut ctx) {
+            _ => ()
+        }
+    })
+}
+
+mod waker {
+    use std::mem::ManuallyDrop;
+    use std::sync::Arc;
+    use std::task::{RawWaker, RawWakerVTable};
+    use std::future::Future;
+
+    pub(super) unsafe fn make_waker<F: Future<Output = ()> + 'static>(arc: &Arc<F>) -> std::task::Waker {
+        std::task::Waker::from_raw(
+            RawWaker::new(Arc::as_ptr(&arc) as *const (), waker_vtable::<F>())
+            )
+    }
+
+    fn waker_vtable<W: Future<Output = ()> + 'static>() -> &'static RawWakerVTable {
+        &RawWakerVTable::new(
+            clone_raw::<W>,
+            wake_raw::<W>,
+            wake_by_ref_raw::<W>,
+            drop_raw::<W>,
+            )
+    }
+
+    unsafe fn clone_raw<T: Future<Output = ()> + 'static>(data: *const ()) -> RawWaker {
+        inc_ref_count::<T>(data);
+        RawWaker::new(data, waker_vtable::<T>())
+    }
+
+    unsafe fn wake_raw<T: Future<Output = ()> + 'static>(data: *const ()) {
+        let arc: Arc<T> = Arc::<T>::from_raw(data as *const T);
+        super::spawn_unsafe(arc)
+    }
+
+    unsafe fn wake_by_ref_raw<T: Future<Output = ()> + 'static>(data: *const ()) {
+        inc_ref_count::<T>(data);
+        wake_raw::<T>(data)
+    }
+
+    unsafe fn inc_ref_count<T: Future<Output = ()>>(data: *const ()) {
+        let arc = ManuallyDrop::new(Arc::<T>::from_raw(data as *const T));
+        let _arc_clone: ManuallyDrop<_> = arc.clone();
+    }
+
+    unsafe fn drop_raw<T: Future<Output = ()>>(data: *const ()) {
+        drop(Arc::<T>::from_raw(data as *const T));
+    }
+}

--- a/iui/src/lib.rs
+++ b/iui/src/lib.rs
@@ -36,6 +36,7 @@ mod ffi_tools;
 pub mod menus;
 pub mod str_tools;
 mod ui;
+pub mod async;
 
 pub use error::UIError;
 pub use ui::{EventLoop, UI};

--- a/iui/src/lib.rs
+++ b/iui/src/lib.rs
@@ -36,7 +36,7 @@ mod ffi_tools;
 pub mod menus;
 pub mod str_tools;
 mod ui;
-pub mod async;
+pub mod concurrent;
 
 pub use error::UIError;
 pub use ui::{EventLoop, UI};

--- a/iui/src/ui.rs
+++ b/iui/src/ui.rs
@@ -12,7 +12,7 @@ use std::thread;
 use std::time::{Duration, SystemTime};
 
 use controls::Window;
-use async::Context;
+use concurrent::Context;
 
 /// RAII guard for the UI; when dropped, it uninits libUI.
 struct UIToken {
@@ -136,13 +136,13 @@ impl UI {
     /// ui.quit();
     /// ```
     pub fn queue_main<F: FnMut() + 'static>(&self, callback: F) {
-        crate::async::queue_main_unsafe(callback)
+        crate::concurrent::queue_main_unsafe(callback)
     }
 
     /// Obtains a context which can be used for queueing tasks on the main
     /// thread.
     pub fn async_context(&self) -> Context {
-        Context {}
+        Context { _pd: PhantomData }
     }
 
     /// Spawns a new asynchronous task on the GUI thread when next possible.
@@ -151,9 +151,9 @@ impl UI {
     /// or when it is awaiting. This version can be used from any thread.
     /// This version doesn't require the future to be `Send`, but can only
     /// be run in the main thread.
-    pub fn spawn<F: std::future::Future<Output = ()> + 'static>(self, future: F) {
+    pub fn spawn<F: std::future::Future<Output = ()> + 'static>(&self, future: F) {
         let arc = std::sync::Arc::new(future);
-        unsafe { crate::async::spawn_unsafe(arc) }
+        unsafe { crate::concurrent::spawn_unsafe(arc) }
     }
 
     /// Set a callback to be run when the application quits.

--- a/iui/src/ui.rs
+++ b/iui/src/ui.rs
@@ -12,6 +12,7 @@ use std::thread;
 use std::time::{Duration, SystemTime};
 
 use controls::Window;
+use async::Context;
 
 /// RAII guard for the UI; when dropped, it uninits libUI.
 struct UIToken {
@@ -135,15 +136,24 @@ impl UI {
     /// ui.quit();
     /// ```
     pub fn queue_main<F: FnMut() + 'static>(&self, callback: F) {
-        extern "C" fn c_callback<G: FnMut()>(data: *mut c_void) {
-            unsafe {
-                from_void_ptr::<G>(data)();
-            }
-        }
+        crate::async::queue_main_unsafe(callback)
+    }
 
-        unsafe {
-            ui_sys::uiQueueMain(Some(c_callback::<F>), to_heap_ptr(callback));
-        }
+    /// Obtains a context which can be used for queueing tasks on the main
+    /// thread.
+    pub fn async_context(&self) -> Context {
+        Context {}
+    }
+
+    /// Spawns a new asynchronous task on the GUI thread when next possible.
+    /// Returns immediately, not waiting for the task to be executed.
+    /// The GUI thread will resume normal operation when the task completes
+    /// or when it is awaiting. This version can be used from any thread.
+    /// This version doesn't require the future to be `Send`, but can only
+    /// be run in the main thread.
+    pub fn spawn<F: std::future::Future<Output = ()> + 'static>(self, future: F) {
+        let arc = std::sync::Arc::new(future);
+        unsafe { crate::async::spawn_unsafe(arc) }
     }
 
     /// Set a callback to be run when the application quits.


### PR DESCRIPTION
In response to #55

Two new methods in `UI`:

1. `async_context` creates a token (`iui::concurrent::Context`) which can serve as evidence that `UI::init()` has run successfully; this token is `Send`
2. `spawn` schedules an async function or future on the main thread. Since it's a method in `UI` it can only be run in the main thread. It returns control to the main loop when it blocks and queues itself again when it's ready again.

Two methods in `concurrent::Context`

1. `queue_main` behaves like `UI::queue_main` in that it schedules a closure or function to run on the main thread. Unlike `UI::queue_main` it can be run in other threads but requires the closure to be `Send`.
2. `spawn` behaves like `UI::spawn` but can be run from other threads; requires the future to be `Send`

Using `UI::spawn` and an async channel such as provided by `tokio::sync::mpsc` we can wait for things to happen on other threads without busy waiting or blocking other events and then update our widgets accordingly.