### PR TITLE
Use libui-ng instead of dormant libui

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ui-sys/libui"]
 	path = ui-sys/libui
-	url = https://github.com/andlabs/libui
+	url = https://github.com/libui-ng/libui-ng

--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -57,6 +57,9 @@ fn main() {
         let src_base = env::var("SRC_BASE").unwrap_or("libui".to_string());
         let src_path = |x| format!("{}/{}", src_base, x);
 
+        // libui might emit lots of warnings we can do nothing
+        base_config.warnings(false);
+
         // Add source files that are common to all platforms
         base_config.include(src_path("/common"));
 
@@ -70,6 +73,7 @@ fn main() {
             "common/matrix.c",
             "common/opentype.c",
             "common/shouldquit.c",
+            "common/table.c",
             "common/tablemodel.c",
             "common/tablevalue.c",
             "common/userbugs.c",


### PR DESCRIPTION
Because libui didn't show any activity for years, i propose to use the active [libui-ng](https://github.com/libui-ng/libui-ng) instead.
No API functions were remove (only added) and it still compiles wonderfully. I only had to:
- add the one new file to the build script.
- hide warnings as we can't do much about them.

I successfully built and then ran a test application on Debian 11 and on Windows 10. I encountered no issues that i could attribute to the updated library.