### PR TITLE
Removed 'regex' and 'lazy_static' dependency

### DIFF
--- a/iui/Cargo.toml
+++ b/iui/Cargo.toml
@@ -40,6 +40,4 @@ bitflags = "1"
 libc = "0.2"
 failure = "0.1"
 ui-sys = { path = "../ui-sys", version = "0.2.1" }
-regex = "1"
-lazy_static = "1"
 

--- a/iui/src/lib.rs
+++ b/iui/src/lib.rs
@@ -21,10 +21,7 @@
 extern crate bitflags;
 #[macro_use]
 extern crate failure;
-#[macro_use]
-extern crate lazy_static;
 extern crate libc;
-extern crate regex;
 extern crate ui_sys;
 
 mod callback_helpers;

--- a/iui/src/str_tools.rs
+++ b/iui/src/str_tools.rs
@@ -11,17 +11,17 @@ pub fn strip_dual_endings(s: &str) -> String {
 
 /// Replaces every occurrence of `"\n"` not led by `"\r"` with `"\r\n"`.
 pub fn insert_dual_endings(s: &str) -> String {
-    let mut ns = String::with_capacity(s.len() + 2);
-    let mut cr = false;
-    for (_, d) in s.char_indices() {
-        if d == '\n' && !cr {
-            ns.push('\r');
+    let mut new_string = String::with_capacity(s.len() + 2);
+    let mut prev_was_cr = false;
+    for (_, character) in s.char_indices() {
+        if character == '\n' && !prev_was_cr {
+            new_string.push('\r');
         }
 
-        ns.push(d);
-        cr = d == '\r';
+        new_string.push(character);
+        prev_was_cr = character == '\r';
     }
-    return ns;
+    return new_string;
 }
 
 /// Converts a &str to a CString, using either LF or CRLF as appropriate.

--- a/iui/src/str_tools.rs
+++ b/iui/src/str_tools.rs
@@ -1,6 +1,5 @@
 //! Tools for making platform-independent string handling work properly
 
-use regex::{Regex, RegexBuilder};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
@@ -10,16 +9,19 @@ pub fn strip_dual_endings(s: &str) -> String {
     s.replace("\r\n", "\n")
 }
 
-/// Replaces every occurrance of `"\n"` not followed by `"\r"` with `"\r\n"`.
+/// Replaces every occurrence of `"\n"` not led by `"\r"` with `"\r\n"`.
 pub fn insert_dual_endings(s: &str) -> String {
-    lazy_static! {
-        //static ref RE: Regex = Regex::new("([^\r])\n").expect("Could not compile regex");
-        static ref RE: Regex = RegexBuilder::new("\r\n|\n")
-                                             .multi_line(true)
-                                             .build()
-                                             .expect("Could not compile regex");
+    let mut ns = String::with_capacity(s.len() + 2);
+    let mut cr = false;
+    for (_, d) in s.char_indices() {
+        if d == '\n' && !cr {
+            ns.push('\r');
+        }
+
+        ns.push(d);
+        cr = d == '\r';
     }
-    RE.replace_all(s, "\r\n").to_string()
+    return ns;
 }
 
 /// Converts a &str to a CString, using either LF or CRLF as appropriate.


### PR DESCRIPTION
I noticed that `insert_dual_endings()` pulls in two dependencies (including a full regex engine) for a task that doesn't really justify their use. As a friend of independent applications and libraries I'd welcome if those two crates can be removed.

Of course the new algorithm passes the unit tests. If you are wondering about the `len+ 2` in `String::with_capacity()`, I though i'd leave room for two inserts before causing an allocation.