### PR TITLE
Add Window::open_folder(), fix memory leak

### DIFF
--- a/iui/src/controls/window.rs
+++ b/iui/src/controls/window.rs
@@ -123,23 +123,42 @@ impl Window {
         unsafe { ui_sys::uiWindowSetChild(self.uiWindow, child.into().as_ui_control()) }
     }
 
-    /// Allow the user to select an existing file.
+    /// Allow the user to select an existing file using the systems file dialog
     pub fn open_file(&self, _ctx: &UI) -> Option<PathBuf> {
         let ptr = unsafe { ui_sys::uiOpenFile(self.uiWindow) };
         if ptr.is_null() {
             return None;
         };
         let path_string: String = unsafe { CStr::from_ptr(ptr).to_string_lossy().into() };
+        unsafe {
+            ui_sys::uiFreeText(ptr);
+        }
         Some(path_string.into())
     }
 
-    /// Allow the user to select a new or existing file.
+    /// Allow the user to select a new or existing file using the systems file dialog.
     pub fn save_file(&self, _ctx: &UI) -> Option<PathBuf> {
         let ptr = unsafe { ui_sys::uiSaveFile(self.uiWindow) };
         if ptr.is_null() {
             return None;
         };
         let path_string: String = unsafe { CStr::from_ptr(ptr).to_string_lossy().into() };
+        unsafe {
+            ui_sys::uiFreeText(ptr);
+        }
+        Some(path_string.into())
+    }
+
+    /// Allow the user to select a single folder using the systems folder dialog.
+    pub fn open_folder(&self, _ctx: &UI) -> Option<PathBuf> {
+        let ptr = unsafe { ui_sys::uiOpenFolder(self.uiWindow) };
+        if ptr.is_null() {
+            return None;
+        };
+        let path_string: String = unsafe { CStr::from_ptr(ptr).to_string_lossy().into() };
+        unsafe {
+            ui_sys::uiFreeText(ptr);
+        }
         Some(path_string.into())
     }
 


### PR DESCRIPTION
Now that you updated to libui-ng we can create system folder dialogs with `uiOpenFolder()`.
While creating the wrapper i noticed that the path returned from the dialog functions is never free'd [although necessary](https://github.com/libui-ng/libui-ng/blob/master/ui.h#L1878), so I did fix that too.