### PR TITLE
Add colorbutton control

### DIFF
--- a/iui/src/controls/colorbutton.rs
+++ b/iui/src/controls/colorbutton.rs
@@ -1,0 +1,63 @@
+use super::Control;
+use callback_helpers::{from_void_ptr, to_heap_ptr};
+use std::mem;
+use std::os::raw::c_void;
+use ui::UI;
+use ui_sys::{self, uiColorButton, uiControl};
+
+define_control! {
+    /// A button-like control which allows the user to pick a color.
+    rust_type: ColorButton,
+    sys_type: uiColorButton
+}
+
+impl ColorButton {
+    /// Create a new color button.
+    pub fn new(_ctx: &UI) -> ColorButton {
+        unsafe { ColorButton::from_raw(ui_sys::uiNewColorButton()) }
+    }
+
+    /// Get the selected color as RGBA with values in range of [0, 1.0] per component.
+    pub fn color(&self, _ctx: &UI) -> (f64, f64, f64, f64) {
+        unsafe {
+            let (mut r, mut g, mut b, mut a) = (0.0, 0.0, 0.0, 0.0);
+            ui_sys::uiColorButtonColor(self.uiColorButton, &mut r, &mut g, &mut b, &mut a);
+            (r, g, b, a)
+        }
+    }
+
+    /// Set the buttons selected color. Components are in the range of [0, 1.0].
+    pub fn set_color(&mut self, _ctx: &UI, r: f64, g: f64, b: f64, a: f64) {
+        unsafe {
+            ui_sys::uiColorButtonSetColor(self.uiColorButton, r, g, b, a);
+        }
+    }
+
+    /// Run the given callback when the selected color changed.
+    ///
+    /// The callback is not triggered when calling `set_color()`.
+    /// Only one callback can be registered at a time.
+    pub fn on_changed<'ctx, F>(&mut self, _ctx: &'ctx UI, callback: F)
+    where
+        F: FnMut(&mut ColorButton) + 'static,
+    {
+        extern "C" fn c_callback<G>(button: *mut uiColorButton, data: *mut c_void)
+        where
+            G: FnMut(&mut ColorButton),
+        {
+            let mut button = ColorButton {
+                uiColorButton: button,
+            };
+            unsafe {
+                from_void_ptr::<G>(data)(&mut button);
+            }
+        }
+        unsafe {
+            ui_sys::uiColorButtonOnChanged(
+                self.uiColorButton,
+                Some(c_callback::<F>),
+                to_heap_ptr(callback),
+            );
+        }
+    }
+}

--- a/iui/src/controls/mod.rs
+++ b/iui/src/controls/mod.rs
@@ -13,6 +13,8 @@ mod label;
 pub use self::label::*;
 mod button;
 pub use self::button::*;
+mod colorbutton;
+pub use self::colorbutton::*;
 mod window;
 pub use self::window::*;
 mod layout;


### PR DESCRIPTION
The colorbutton control from libui-ng. It should seamlessly integrate into this library. Care was taken that all naming and arguments match libui-rs as good as possible.

One point of interest is `color()`: One could argue that returning `(f64, f64, f64, f64)` is lazy and a full `Color` type is better. I felt that this is overkill because the user likely already has a color class that much better fits his needs than we could anticipate.

For testing I used my [controlgallery example](https://github.com/nptr/libui-rs/tree/feature/tables/iui/examples/controlgallery) (rust port from the [libui-ng one](https://github.com/libui-ng/libui-ng/tree/master/examples/controlgallery)). I plan to make a PR for this as well, but only after the new controls were merged - because it depends on them and piecewise including it in PRs is tedious :)