### PR TITLE
Add datetimepicker control

### DIFF
--- a/iui/src/controls/datetimepicker.rs
+++ b/iui/src/controls/datetimepicker.rs
@@ -1,0 +1,96 @@
+use super::Control;
+use callback_helpers::{from_void_ptr, to_heap_ptr};
+use std::mem;
+use std::os::raw::c_void;
+use ui::UI;
+use ui_sys::{self, uiControl, uiDateTimePicker};
+
+define_control! {
+    /// Allows to enter a date and/or time.
+    rust_type: DateTimePicker,
+    sys_type: uiDateTimePicker
+}
+
+pub enum DateTimePickerKind {
+    DateTime,
+    Date,
+    Time,
+}
+
+impl DateTimePicker {
+    /// Create a new date and/or time picker.
+    pub fn new(_ctx: &UI, mode: DateTimePickerKind) -> DateTimePicker {
+        unsafe {
+            DateTimePicker::from_raw(match mode {
+                DateTimePickerKind::DateTime => ui_sys::uiNewDateTimePicker(),
+                DateTimePickerKind::Date => ui_sys::uiNewDatePicker(),
+                DateTimePickerKind::Time => ui_sys::uiNewTimePicker(),
+            })
+        }
+    }
+
+    /// Returns the date and/or time stored in the DateTimePicker.
+    ///
+    /// Depending on the `DateTimePickerKind` you created, the date or time fields
+    /// will not be set and instead contain their unix epoch default.
+    ///
+    /// Warning: The `struct tm` member `tm_isdst` is unused on Windows and will be `-1`.
+    pub fn datetime(&self, _ctx: &UI) -> libc::tm {
+        unsafe {
+            let mut datetime = libc::tm {
+                tm_sec: 0,
+                tm_min: 0,
+                tm_hour: 0,
+                tm_mday: 0,
+                tm_mon: 0,
+                tm_year: 0,
+                tm_wday: 0,
+                tm_yday: 0,
+                tm_isdst: 0,
+                tm_gmtoff: 0,
+                tm_zone: std::ptr::null(),
+            };
+            let ptr = &mut datetime as *mut libc::tm;
+            ui_sys::uiDateTimePickerTime(self.uiDateTimePicker, ptr as *mut ui_sys::tm);
+            datetime
+        }
+    }
+
+    /// Sets date and time of the DateTimePicker.
+    ///
+    /// Warning: The `struct tm` member `tm_isdst` is ignored on Windows and should be set to `-1`
+    pub fn set_datetime(&self, _ctx: &UI, datetime: libc::tm) {
+        unsafe {
+            let ptr = &datetime as *const libc::tm;
+            ui_sys::uiDateTimePickerSetTime(self.uiDateTimePicker, ptr as *const ui_sys::tm);
+        }
+    }
+
+    /// Registers a callback for when the date time picker value is changed by the user.
+    ///
+    /// The callback is not triggered when calling `set_datetime()`.
+    /// Only one callback can be registered at a time.
+    pub fn on_changed<'ctx, F>(&mut self, _ctx: &'ctx UI, callback: F)
+    where
+        F: FnMut(&mut DateTimePicker) + 'static,
+    {
+        extern "C" fn c_callback<G>(picker: *mut uiDateTimePicker, data: *mut c_void)
+        where
+            G: FnMut(&mut DateTimePicker),
+        {
+            let mut picker = DateTimePicker {
+                uiDateTimePicker: picker,
+            };
+            unsafe {
+                from_void_ptr::<G>(data)(&mut picker);
+            }
+        }
+        unsafe {
+            ui_sys::uiDateTimePickerOnChanged(
+                self.uiDateTimePicker,
+                Some(c_callback::<F>),
+                to_heap_ptr(callback),
+            );
+        }
+    }
+}

--- a/iui/src/controls/mod.rs
+++ b/iui/src/controls/mod.rs
@@ -13,6 +13,8 @@ mod label;
 pub use self::label::*;
 mod button;
 pub use self::button::*;
+mod datetimepicker;
+pub use self::datetimepicker::*;
 mod window;
 pub use self::window::*;
 mod layout;


### PR DESCRIPTION
The DateTimePicker control from libui-ng. It should seamlessly integrate into this library. Care was taken that all naming and arguments match libui-rs as good as possible.

I am not fully sure about using the `libc::tm` struct in the interface to the user.

**Cons:**
* not user friendly because its a 1:1 C wrapper

**Pros:**
* no need to design yet another DateTime class
* should be highly interoperable with any DateTime crate

For testing I used my [controlgallery example](https://github.com/nptr/libui-rs/tree/feature/tables/iui/examples/controlgallery) (rust port from the [libui-ng one](https://github.com/libui-ng/libui-ng/tree/master/examples/controlgallery)). I plan to make a PR for this as well, but only after the new controls were merged - because it depends on them and piecewise including it in PRs is tedious :)