### PR TITLE
Add form layout

### DIFF
--- a/iui/src/controls/form.rs
+++ b/iui/src/controls/form.rs
@@ -1,0 +1,73 @@
+use super::{Control, LayoutStrategy};
+use std::ffi::CString;
+use std::mem;
+use std::os::raw::c_int;
+use ui::UI;
+use ui_sys::{self, uiControl, uiForm};
+
+define_control! {
+    /// A container that labels its childen.
+    ///
+    /// Labels and controls are organized into two panes, making both labels
+    /// and controls align with each other. Perfect to create aesthetically
+    /// pleasing input forms.
+    rust_type: Form,
+    sys_type: uiForm
+}
+
+impl Form {
+    /// Create a new Form
+    pub fn new(_ctx: &UI) -> Form {
+        unsafe { Form::from_raw(ui_sys::uiNewForm()) }
+    }
+
+    /// Appends a control with a label to the form.
+    pub fn append<T: Into<Control>>(
+        &mut self,
+        ctx: &UI,
+        label: &str,
+        child: T,
+        strategy: LayoutStrategy,
+    ) {
+        let stretchy = match strategy {
+            LayoutStrategy::Compact => false,
+            LayoutStrategy::Stretchy => true,
+        };
+        let control = child.into();
+        unsafe {
+            let c_string = CString::new(label.as_bytes().to_vec()).unwrap();
+            assert!(ctx.parent_of(control.clone()).is_none());
+            ui_sys::uiFormAppend(
+                self.uiForm,
+                c_string.as_ptr(),
+                control.ui_control,
+                stretchy as c_int,
+            )
+        }
+    }
+
+    /// Returns the number of controls contained within the form.
+    pub fn count(&self, _ctx: &UI) -> i32 {
+        unsafe { ui_sys::uiFormNumChildren(self.uiForm) }
+    }
+
+    /// Removes the control at `index` from the form.
+    pub fn delete(&mut self, _ctx: &UI, index: i32) {
+        unsafe { ui_sys::uiFormDelete(self.uiForm, index) }
+    }
+
+    /// Returns whether or not controls within the form are padded.
+    pub fn padded(&self, _ctx: &UI) -> bool {
+        unsafe { ui_sys::uiFormPadded(self.uiForm) != 0 }
+    }
+
+    /// Sets whether or not controls within the form are padded.
+    ///
+    /// Padding is defined as space between individual controls.
+    /// The padding size is determined by the OS defaults.
+    pub fn set_padded(&mut self, _ctx: &UI, padded: bool) {
+        unsafe {
+            ui_sys::uiFormSetPadded(self.uiForm, padded as c_int);
+        }
+    }
+}

--- a/iui/src/controls/mod.rs
+++ b/iui/src/controls/mod.rs
@@ -15,6 +15,8 @@ mod button;
 pub use self::button::*;
 mod window;
 pub use self::window::*;
+mod form;
+pub use self::form::*;
 mod layout;
 pub use self::layout::*;
 mod entry;


### PR DESCRIPTION
The Form control/layout from libui-ng. It should seamlessly integrate into this library. Care was taken that all naming and arguments match libui-rs as good as possible. I chose however to implement it in its own file rather than in `layout.rs`.

For testing I used my [controlgallery example](https://github.com/nptr/libui-rs/tree/development/iui/examples/controlgallery) (rust port from the [libui-ng one](https://github.com/libui-ng/libui-ng/tree/master/examples/controlgallery)). I plan to make a PR for this as well, but only after the new controls were merged - because it depends on them and piecewise including it in PRs is tedious :)

@NoraCodes: This PR solves issue #119.